### PR TITLE
chore(user-agent): add parser rule for ubuntu

### DIFF
--- a/src/user-agent-parser.test.ts
+++ b/src/user-agent-parser.test.ts
@@ -74,6 +74,18 @@ test('It should get Linux platform', () => {
   expect(result.version).toBe('0.0');
 });
 
+test('It should get Ubuntu platform', () => {
+  // Given
+  const userAgent = 'Chrome 80.0.3987.132 / Ubuntu 20.04';
+
+  // When
+  const result = getPlatformFrom(userAgent);
+
+  // Then
+  expect(result.name).toBe('ubuntu');
+  expect(result.version).toBe('20.04');
+});
+
 test('It should get Windows platform on Windows 10', () => {
   // Given
   const userAgent = 'Chrome 80.0.3987.149 / Windows 10';

--- a/src/user-agent-parser.ts
+++ b/src/user-agent-parser.ts
@@ -63,6 +63,12 @@ export function getPlatformFrom(userAgent: string | undefined): Platform {
       version: platformInfo.version,
     };
   }
+  if (isUbuntu(platformInfo.name)) {
+    return {
+      name: 'ubuntu',
+      version: platformInfo.version,
+    };
+  }
   if (isWindows(platformInfo.name)) {
     return {
       name: 'windows',
@@ -131,6 +137,14 @@ export function isLinux(platformName: string | undefined): boolean {
     return false;
   }
   const result = platformName.toLowerCase().includes('linux');
+  return result;
+}
+
+export function isUbuntu(platformName: string | undefined): boolean {
+  if (platformName === undefined) {
+    return false;
+  }
+  const result = platformName.toLowerCase().includes('ubuntu');
   return result;
 }
 


### PR DESCRIPTION
Thanks for this nice plugin!

I found it failing to detect the platform on Ubuntu